### PR TITLE
test #10: add database testing infrastructure; tests and fixes for Base.

### DIFF
--- a/lib/model/base.js
+++ b/lib/model/base.js
@@ -3,10 +3,15 @@ const { merge } = require('../util');
 
 const Base = (db) =>
   class {
-    constructor(data, ephemeral = true) {
+    constructor(data = {}, ephemeral = true) {
       this.data = data;
       this._ephemeral = ephemeral;
     }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // BASIC PROPERTIES
+
+    get ephemeral() { return this._ephemeral; }
 
     serialize() { return this.data; }
 
@@ -33,7 +38,7 @@ const Base = (db) =>
     // DATABASE QUERYING
 
     // Gets one or more entire records from the database by id; instantiates
-    // the model object. May be single object or array (if id is not unique).
+    // the model object. Will always be an array containing result(s).
     static getById(id) {
       return db.select('*').from(this._tableName()).where({ id })
         .then((rows) => rows.map((row) => new this(row, false)));

--- a/test/model/base.js
+++ b/test/model/base.js
@@ -1,0 +1,211 @@
+const should = require('should');
+const { DatabaseShim } = require('./package');
+
+const Base = require('../../lib/model/base');
+
+describe('Base model', () => {
+  describe('create', () => {
+    it('should insert into the appropriate table specified by tableName', () => {
+      const [ TestBase, shim ] = DatabaseShim.shim(Base);
+      const TestSubclass = class extends TestBase {
+        static _tableName() { return 'test_table'; }
+      }
+
+      const model = new TestSubclass();
+      model.create();
+
+      shim.should.be.calledOnceWith('into', 'test_table');
+    });
+
+    it('should save the provided data', () => {
+      const [ TestBase, shim ] = DatabaseShim.shim(Base);
+      const data = { a: 4, b: 8, c: 15, d: 16 };
+
+      const model = new TestBase(data);
+      model.create();
+
+      // check that all k/v pairs of our given data are present.
+      const [ insertedData ] = shim.paramsForCall('insert');
+      for (const key in data)
+        insertedData[key].should.equal(data[key]);
+    });
+
+    it('should inject the creation date', () => {
+      const [ TestBase, shim ] = DatabaseShim.shim(Base);
+
+      const model = new TestBase({ e: 23, f: 42 });
+      model.create();
+
+      const [ insertedData ] = shim.paramsForCall('insert');
+      insertedData.should.have.property('createdAt');
+      insertedData.createdAt.should.be.an.instanceof(Date);
+    });
+
+    it('should return a new instance of the appropriate subclass', () => {
+      const [ TestBase, shim ] = DatabaseShim.shim(Base);
+      const TestSubclass = class extends TestBase {
+        paranoia() { return true; }
+      }
+
+      const model = new TestSubclass();
+      model.create();
+
+      const [ promiseCallback ] = shim.paramsForCall('then');
+      promiseCallback.should.be.a.Function;
+
+      const returnedModel = promiseCallback([]);
+      returnedModel.should.be.an.instanceof(TestSubclass);
+    });
+
+    it('should populate the returned model with the appropriate attributes', () => {
+      const [ TestBase, shim ] = DatabaseShim.shim(Base);
+
+      const model = new TestBase({ useless: 'data' });
+      model.create();
+
+      const data = { useful: 'data', is: 'nice' };
+      const [ promiseCallback ] = shim.paramsForCall('then');
+      const returnedModel = promiseCallback([ data ]);
+      returnedModel.data.should.eql(data);
+    });
+
+    it('should mark the returned model as nonephemeral', () => {
+      const [ TestBase, shim ] = DatabaseShim.shim(Base);
+
+      const model = new TestBase({ useless: 'data' });
+      model.create();
+
+      const [ promiseCallback ] = shim.paramsForCall('then');
+      const returnedModel = promiseCallback([]);
+      returnedModel.ephemeral.should.equal(false);
+    });
+  });
+
+  describe('update', () => {
+    it('should update the appropriate table specified by tableName', () => {
+      const [ TestBase, shim ] = DatabaseShim.shim(Base);
+      const TestSubclass = class extends TestBase {
+        static _tableName() { return 'test_table'; }
+      }
+
+      const model = new TestSubclass();
+      model.update();
+
+      shim.should.be.calledOnceWith('into', 'test_table');
+    });
+
+    it('should save the provided data', () => {
+      const [ TestBase, shim ] = DatabaseShim.shim(Base);
+      const data = { a: 4, b: 8, c: 15, d: 16 };
+
+      const model = new TestBase(data);
+      model.update();
+
+      // check that all k/v pairs of our given data are present.
+      const [ updatedData ] = shim.paramsForCall('update');
+      for (const key in data)
+        updatedData[key].should.equal(data[key]);
+    });
+
+    it('should inject the update date', () => {
+      const [ TestBase, shim ] = DatabaseShim.shim(Base);
+
+      const model = new TestBase({ e: 23, f: 42 });
+      model.update();
+
+      const [ updatedData ] = shim.paramsForCall('update');
+      updatedData.should.have.property('updatedAt');
+      updatedData.updatedAt.should.be.an.instanceof(Date);
+    });
+
+    it('should only update the appropriate row by id', () => {
+      const [ TestBase, shim ] = DatabaseShim.shim(Base);
+
+      const model = new TestBase({ id: 1138 });
+      model.update();
+
+      shim.should.be.calledOnceWith('where', [{ id: 1138 }]);
+    });
+
+    it('should return the success of the operation as a boolean', () => {
+      const [ TestBase, shim ] = DatabaseShim.shim(Base);
+
+      const model = new TestBase();
+      model.update();
+
+      const [ promiseCallback ] = shim.paramsForCall('then');
+      promiseCallback.should.be.a.Function;
+      promiseCallback({ rowCount: 0 }).should.equal(false);
+      promiseCallback({ rowCount: 1 }).should.equal(true);
+    });
+  });
+
+  describe('static getters', () => {
+    describe('getById', () => {
+      it('should select from the appropriate table matching the given id', () => {
+        const [ TestBase, shim ] = DatabaseShim.shim(Base);
+        const TestSubclass = class extends TestBase {
+          static _tableName() { return 'testing'; }
+        };
+
+        TestSubclass.getById(42);
+
+        shim.should.be.calledOnceWith('select', '*');
+        shim.should.be.calledOnceWith('from', 'testing');
+        shim.should.be.calledOnceWith('where', { id: 42 });
+      });
+
+      it('should return instances of the appropriate class', () => {
+        const [ TestBase, shim ] = DatabaseShim.shim(Base);
+        const TestSubclass = class extends TestBase {};
+
+        TestSubclass.getById(42);
+
+        const [ promiseCallback ] = shim.paramsForCall('then');
+        promiseCallback.should.be.a.Function;
+
+        const returnedInstances = promiseCallback([ null, null ]);
+        returnedInstances.length.should.equal(2);
+        returnedInstances[0].should.be.an.instanceof(TestSubclass);
+        returnedInstances[1].should.be.an.instanceof(TestSubclass);
+      });
+
+      it('should return nonephemeral models with the appropriate data', () => {
+        const [ TestBase, shim ] = DatabaseShim.shim(Base);
+
+        TestBase.getById(42);
+
+        const [ promiseCallback ] = shim.paramsForCall('then');
+        const [ returnedInstance ] = promiseCallback([{ a: 2, b: 3, c: 1 }]);
+        returnedInstance.ephemeral.should.equal(false);
+        returnedInstance.data.should.eql({ a: 2, b: 3, c: 1 });
+      });
+    });
+
+    describe('getCount', () => {
+      it('should select from the appropriate table matching the given conditions', () => {
+        const [ TestBase, shim ] = DatabaseShim.shim(Base);
+        const TestSubclass = class extends TestBase {
+          static _tableName() { return 'a_test'; }
+        };
+
+        TestSubclass.getCount({ some: 'conditions', go: 'here' });
+
+        shim.should.be.calledOnceWith('count', '*');
+        shim.should.be.calledOnceWith('from', 'a_test');
+        shim.should.be.calledOnceWith('where', { some: 'conditions', go: 'here' });
+      });
+
+      it('should return the count supplied by the database', () => {
+        const [ TestBase, shim ] = DatabaseShim.shim(Base);
+
+        TestBase.getCount();
+
+        const [ promiseCallback ] = shim.paramsForCall('then');
+        promiseCallback.should.be.a.Function;
+        promiseCallback([{ count: 47 }]).should.equal(47);
+      });
+    });
+  });
+});
+

--- a/test/model/package.js
+++ b/test/model/package.js
@@ -1,0 +1,75 @@
+////////////////////////////////////////////////////////////////////////////////
+// TEST UTILITIES
+// Primarily, this file contains a test utility to make testing chained knex
+// expressions easier. But it may grow to include more database testing
+// utilities eventually.
+
+const should = require('should');
+
+// Create a standard knex object, then replace all methods we find with a test
+// harness.
+const knex = require('knex')({ client: 'pg' });
+const shim = (methodName) => function(...args) {
+  this.__calls.push([ methodName, args ])
+  return this;
+};
+for (const method in knex)
+  if (typeof knex[method] === 'function')
+    knex[method] = shim(method);
+
+// Also, insert Promise methods.
+for (const method of [ 'then' ])
+  knex[method] = shim(method);
+
+// Now create a public-facing infrastructure for creating, managing, and easily
+// testing these shims.
+class DatabaseShim {
+  constructor() {
+    this._knex = Object.create(knex);
+    this._knex.__calls = [];
+  }
+
+  get database() { return this._knex; }
+
+  get calls() { return this.database.__calls.map(([ methodName, _ ]) => methodName); }
+  get should() {
+    // TODO: memoize for perf.
+    const assertions = {
+      called: (methodName) =>
+        this.database.__calls.any(([ calledName, _ ]) => calledName === methodName).should.equal(true),
+      calledOnce: (methodName) =>
+        this.database.__calls.filter(([ calledName, _ ]) => calledName === methodName).length.should.equal(1),
+      calledWith: (methodName, params) => {
+        const paramsArray = Array.isArray(params) ? params : [ params ];
+        const calledWith = this.paramsForCall(methodName);
+        should.exist(calledWith);
+        calledWith.should.eql(paramsArray);
+      },
+      calledOnceWith: (methodName, params) => {
+        assertions.calledOnce(methodName);
+        assertions.calledWith(methodName, params);
+      }
+    };
+    assertions.be = assertions; // natural language: (.should.be.etc).
+    return assertions;
+  }
+
+  // Returns the supplied parameters of the **first** instance of a given method
+  // call. For multiple calls, filter the full call list.
+  paramsForCall(methodName) {
+    const call = this.database.__calls.find(([ calledName, _ ]) => calledName === methodName);
+    return (call == null) ? null : call[1];
+  }
+
+  // Cuts down on boilerplate; given a pre-injection model class object returns
+  // a tuple containing:
+  // * a class object with the database shim inserted.
+  // * the shim object for test assertions.
+  static shim(modelClass) {
+    const shim = new DatabaseShim();
+    return [ modelClass(shim.database), shim ];
+  };
+}
+
+module.exports = { DatabaseShim };
+


### PR DESCRIPTION
* the DatabaseShim is the main harness for testing knex’s database
  chaining calls.
  * our Model (Base-derived) objects all use dependency injection to
    actually receive their database objects to work with. What the
    DatabaseShim does is create a mock knex object with all the knex and
    Promise methods mocked out for chaining; but instead of actually
    performing any database actions, they simply record what they were
    called with and move on.
  * the Shim itself provides access to these recorded method calls, and
    a bunch of convenience getters and assertions for pulling out the
    relevant calls and parameters for testing.
* it is a bit of a fine balance between testing the appropriate pieces
  of logic for the database calls and over-testing fairly obvious code,
  but in general expected behaviour should be tested (returning objects
  of the correct type, performing various transformations on the data,
  etc) so that if/as the project grows more complex, our basic contracts
  are not violated.
* closes #10; although more work is needed to expand coverage on extant
  model code.