### PR TITLE
new #34: add api version to application route; expose on request obj.

### DIFF
--- a/lib/problem.js
+++ b/lib/problem.js
@@ -49,7 +49,10 @@ const problems = {
     notFound: problem(404.1, () => 'Could not find the resource you were looking for.'),
 
     // missing API version.
-    missingApiVersion: problem(404.2, () => 'Expected an API version (eg /v1) at the start of the request URL.')
+    missingApiVersion: problem(404.2, () => 'Expected an API version (eg /v1) at the start of the request URL.'),
+
+    // unexpected API version.
+    unexpectedApiVersion: problem(404.3, ({ got }) => `Unexpected an API version (accepts: 1) (got: ${got}).`)
   },
   internal: {
     // no detail information, as this is only called when we don't know what happened.

--- a/lib/problem.js
+++ b/lib/problem.js
@@ -46,7 +46,10 @@ const problems = {
     insufficientRights: problem(403.1, () => 'The authenticated actor does not have rights to perform that action.'),
 
     // no detail information as the problem should be self-evident by REST conventions.
-    notFound: problem(404.1, () => 'Could not find the resource you were looking for.')
+    notFound: problem(404.1, () => 'Could not find the resource you were looking for.'),
+
+    // missing API version.
+    missingApiVersion: problem(404.2, () => 'Expected an API version (eg /v1) at the start of the request URL.')
   },
   internal: {
     // no detail information, as this is only called when we don't know what happened.

--- a/lib/server.js
+++ b/lib/server.js
@@ -25,9 +25,10 @@ service.use(bodyParser.text({ type: '*/*' }));
 const morgan = require('morgan');
 service.use(morgan('common'));
 
-// pull session information and pass it on, or reject the request if broken
-// credentials are provided.
-const { sessionParser } = require('./util/http');
+// pull session and version information and pass it on, or reject the request if
+// broken information is provided for either.
+const { versionParser, sessionParser } = require('./util/http');
+service.use(versionParser);
 service.use(sessionParser(container));
 
 

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -74,6 +74,17 @@ const sendError = (error, request, response) => {
   }
 };
 
+// Strips a /v# prefix off the request path and exposes on the request object
+// under the apiVersion property.
+const versionParser = (request, response, next) => {
+  // this code will all break when we hit version 10 a century from now.
+  const match = /^\/v(\d)\//.exec(request.url);
+  if (match == null) return next(Problem.user.missingApiVersion());
+  request.apiVersion = Number(match[1]);
+  request.url = request.url.slice(3);
+  next();
+};
+
 // Wraps a service, and injects the appropriate session information given the
 // appropriate credentials. If the given credentials don't match a session, aborts
 // with a 401. If no credentials are given, injects an empty session.
@@ -101,5 +112,5 @@ const getOrReject = (rejection) => (option) =>
   (option.isDefined() ? option.get() : reject(rejection));
 const getOrNotFound = getOrReject(Problem.user.notFound());
 
-module.exports = { serialize, endpoint, sendError, sessionParser, getOrElse, getOrReject, getOrNotFound };
+module.exports = { serialize, endpoint, sendError, versionParser, sessionParser, getOrElse, getOrReject, getOrNotFound };
 

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -81,6 +81,7 @@ const versionParser = (request, response, next) => {
   const match = /^\/v(\d)\//.exec(request.url);
   if (match == null) return next(Problem.user.missingApiVersion());
   request.apiVersion = Number(match[1]);
+  if (request.apiVersion !== 1) return next(Problem.user.unexpectedApiVersion({ got: match[1] }));
   request.url = request.url.slice(3);
   next();
 };


### PR DESCRIPTION
* closes #34.
* check request.apiVersion to see the version of the request.
* this could change if eg we’d prefer to actually route based on the
  version, in which case we can simply submount services instead.