### PR TITLE
bug: password reset no-account branch was not inert.

### DIFF
--- a/lib/resources/users.js
+++ b/lib/resources/users.js
@@ -33,7 +33,7 @@ module.exports = (service, { Actee, User, mail }) => {
           : resolve(user))
           .then(() => user.provisionPasswordResetToken()
             .then((token) => mail(body.email, 'accountReset', { token }))))
-        .orElse(mail(body.email, 'accountResetFailure'))
+        .orElseGet(() => mail(body.email, 'accountResetFailure'))
         .then(success))));
 
   // TODO: some standard URL structure for RPC-style methods.

--- a/test/api/hooks.js
+++ b/test/api/hooks.js
@@ -1,0 +1,8 @@
+// declare our universal beforeEach, etc hooks for all tests.
+
+beforeEach(() => {
+  // reset the email inbox so that we can reliably count all the messages sent
+  // by a single particular operation.
+  global.inbox = [];
+});
+

--- a/test/api/resources/users.js
+++ b/test/api/resources/users.js
@@ -58,6 +58,7 @@ describe('api: /users', () => {
           .expect(200)
           .then(() => {
             const email = global.inbox.pop();
+            global.inbox.length.should.equal(0);
             email.to.should.eql([{ address: 'david@opendatakit.org', name: '' }]);
             email.subject.should.equal('Data collection account created');
           }))));
@@ -92,6 +93,7 @@ describe('api: /users', () => {
         .expect(200)
         .then(() => {
           const email = global.inbox.pop();
+          global.inbox.length.should.equal(0);
           email.to.should.eql([{ address: 'winnifred@opendatakit.org', name: '' }]);
           email.subject.should.equal('Data collection account password reset');
           email.html.should.match(/no account exists/);
@@ -103,6 +105,7 @@ describe('api: /users', () => {
         .expect(200)
         .then(() => {
           const email = global.inbox.pop();
+          global.inbox.length.should.equal(0);
           email.to.should.eql([{ address: 'alice@opendatakit.org', name: '' }]);
           email.subject.should.equal('Data collection account password reset');
           const token = /token=([^<]+)<\/p>/.exec(email.html)[1];
@@ -128,6 +131,7 @@ describe('api: /users', () => {
           .then(() => {
             // should still send the email.
             const email = global.inbox.pop();
+            global.inbox.length.should.equal(0);
             email.to.should.eql([{ address: 'bob@opendatakit.org', name: '' }]);
             email.subject.should.equal('Data collection account password reset');
 


### PR DESCRIPTION
* orElse(mail(… calls immediately. so use orElseGet instead.
* modify tests so that we're sure the right number of emails are sent.