### PR TITLE
improve+test #75: sort revoked field keys to the bottom of the listing.

### DIFF
--- a/lib/model/query/field-keys.js
+++ b/lib/model/query/field-keys.js
@@ -26,6 +26,7 @@ module.exports = {
       .join('actors', 'field_keys.actorId', 'actors.id')
       .leftOuterJoin('sessions', 'field_keys.actorId', 'sessions.actorId')
       .where({ 'actors.deletedAt': null })
+      .orderByRaw('(sessions.token is not null) desc')
       .orderBy('actors.createdAt', 'desc')
       .then((rows) => rows.map(joinRowToInstance('fieldKey', {
         fieldKey: FieldKey,
@@ -54,6 +55,7 @@ module.exports = {
         'field_keys.actorId', 'last_usage.actorId'
       )
       .where({ 'actors.deletedAt': null })
+      .orderByRaw('(sessions.token is not null) desc')
       .orderBy('actors.createdAt', 'desc')
       .then((rows) => rows.map(joinRowToInstance('fieldKey', {
         fieldKey: FieldKey,


### PR DESCRIPTION
* ie if the field key no longer has an active session, it goes to the
  bottom.
* otherwise it still sorts descending by creation date.
* resolves #75.