### PR TITLE
Redo the backups status API a little bit.

### DIFF
--- a/lib/bin/backup.js
+++ b/lib/bin/backup.js
@@ -10,12 +10,13 @@ const { initDrive, ensureDirectory, uploadFile, persistCredentials } = require('
 run(auditing('backup', async () => {
   // fetch backup config. automatically fails out unless it exists.
   const config = await getConfiguration('backups.main');
+  const configValue = JSON.parse(config.value);
 
   // run the pgdump and encrypt it into a zipfile.
   const [ tmpdirPath, tmpdirRm ] = await tmpdir();
   await pgdump(tmpdirPath);
   const tmpfilePath = await tmpfile();
-  await encryptToArchive(tmpdirPath, tmpfilePath, config.keys);
+  await encryptToArchive(tmpdirPath, tmpfilePath, configValue.keys);
   tmpdirRm();
 
   // upload to google drive.

--- a/lib/bin/backup.js
+++ b/lib/bin/backup.js
@@ -29,6 +29,6 @@ run(auditing('backup', async () => {
     persistCredentials(drive);
   }
 
-  return 'success';
+  return { success: true, configSetAt: config.setAt };
 }));
 

--- a/lib/model/instance/audit.js
+++ b/lib/model/instance/audit.js
@@ -20,5 +20,7 @@ module.exports = Instance(({ audits, Audit, simply }) => class {
 
   static getLatestByAction(action) { return audits.getLatestWhere({ action }); }
   static getLatestWhere(condition) { return audits.getLatestWhere(condition); }
+
+  static getRecentByAction(action, duration) { return audits.getRecentWhere({ action }, duration); }
 });
 

--- a/lib/model/instance/config.js
+++ b/lib/model/instance/config.js
@@ -1,8 +1,6 @@
 const Instance = require('./instance');
 
 module.exports = Instance(({ Config, simply, configs }) => class {
-  forApi() { return this.value; }
-
   static set(key, value) { return configs.set(new Config({ key, value })); }
   static unset(key) { return simply.delete('config', { key }, 'key'); }
   static get(key) { return simply.getOneWhere('config', { key }, Config); }

--- a/lib/model/migrations/20180501-01-add-configs-timestamp.js
+++ b/lib/model/migrations/20180501-01-add-configs-timestamp.js
@@ -1,0 +1,8 @@
+const up = (knex) =>
+  knex.schema.table('config', (config) => { config.dateTime('setAt'); });
+
+const down = (knex) =>
+  knex.schema.table('config', (config) => { config.dropColumn('setAt'); });
+
+module.exports = { up, down };
+

--- a/lib/model/query/audits.js
+++ b/lib/model/query/audits.js
@@ -1,4 +1,5 @@
-const { maybeRowToInstance } = require('../../util/db');
+const { DateTime, Duration } = require('luxon');
+const { maybeRowToInstance, rowsToInstances } = require('../../util/db');
 
 module.exports = {
   getLatestWhere: (condition) => ({ db, Audit }) =>
@@ -6,6 +7,13 @@ module.exports = {
       .where(condition)
       .orderBy('loggedAt', 'desc')
       .limit(1)
-      .then(maybeRowToInstance(Audit))
+      .then(maybeRowToInstance(Audit)),
+
+  getRecentWhere: (condition, duration = { days: 3 }) => ({ db, Audit }) =>
+    db.select('*').from('audits')
+      .where(condition)
+      .where('loggedAt', '>=', DateTime.local().minus(Duration.fromObject(duration)))
+      .orderBy('loggedAt', 'desc')
+      .then(rowsToInstances(Audit))
 };
 

--- a/lib/model/query/configs.js
+++ b/lib/model/query/configs.js
@@ -1,8 +1,9 @@
 module.exports = {
   set: (record) => ({ db }) =>
-    db.raw('? on conflict (key) do update set value = ?', [
-      db.insert(record).into('config'),
-      record.value
+    db.raw('? on conflict (key) do update set value = ?, "setAt" = ?', [
+      db.insert(record.with({ setAt: new Date() })).into('config'),
+      record.value,
+      new Date()
     ])
 };
 

--- a/lib/resources/config.js
+++ b/lib/resources/config.js
@@ -13,10 +13,10 @@ module.exports = (service, { all, Actor, Actee, Audit, Config, Session, google }
   // TODO: i have no idea what this /ought/ to return.
   service.get('/config/backups', endpoint(({ auth }) =>
     auth.canOrReject('read', Actee.species('config')) // TODO: goofy.
-      .then(() => all.do([ Config.get('backups.main'), Audit.getLatestByAction('backup') ]))
-      .then(([ config, audit ]) => {
+      .then(() => all.do([ Config.get('backups.main'), Audit.getRecentByAction('backup') ]))
+      .then(([ config, audits ]) => {
         if (!config.isDefined()) return getOrNotFound(config); // TODO: hyper-awkward.
-        return { config: omit([ 'keys' ], JSON.parse(config.get().value)), latest: audit.orNull() };
+        return { type: JSON.parse(config.get().value).type, setAt: config.get().setAt, recent: audits };
       })));
 
   // even if a backup isn't actually set up, we just idempotently clear out the

--- a/lib/task/config.js
+++ b/lib/task/config.js
@@ -2,11 +2,11 @@ const { task } = require('./task');
 const { getOrNotFound } = require('../util/promise');
 
 const getConfiguration = task.withContainer(({ Config }) => (key) =>
-  Config.get(key)
-    .then(getOrNotFound)
-    .then((x) => JSON.parse(x.value)));
+  Config.get(key).then(getOrNotFound));
+
+const getConfigurationJsonValue = (key) => getConfiguration(key).then((config) => JSON.parse(config.value));
 
 const setConfiguration = task.withContainer(({ Config }) => Config.set);
 
-module.exports = { getConfiguration, setConfiguration };
+module.exports = { getConfiguration, getConfigurationJsonValue, setConfiguration };
 

--- a/lib/task/google.js
+++ b/lib/task/google.js
@@ -1,7 +1,7 @@
 const config = require('config');
 const { task } = require('./task');
 const google = require('../outbound/google');
-const { getConfiguration, setConfiguration } = require('./config');
+const { getConfigurationJsonValue, setConfiguration } = require('./config');
 
 
 // compares google credential objects.
@@ -9,7 +9,7 @@ const credentialsChanged = (a, b) =>
   (a.access_token !== b.access_token) || (a.expiry_date !== b.expiry_date) || (a.refresh_token !== b.refresh_token);
 
 // get a google drive api class given our credentials.
-const initDrive = (configKey) => getConfiguration(configKey).then((credentials) => {
+const initDrive = (configKey) => getConfigurationJsonValue(configKey).then((credentials) => {
   const { auth, drive } = google(config.get('default.external.google'));
   auth.setCredentials(credentials);
   return { auth, configKey, credentials, api: drive };

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -10,6 +10,7 @@ const { promisify, inspect } = require('util');
 const { merge, compose } = require('ramda');
 const config = require('config');
 const Problem = require('../util/problem');
+const Option = require('../util/option');
 const { connect } = require('../model/database');
 const pkg = require('../model/package');
 const { finalize } = require('../http/endpoint');
@@ -76,14 +77,13 @@ const fault = (error) => {
 
 // does its best to ensure that the result of the task is audit-logged.
 // either logs a success or a failure with an attached error message.
-const auditLog = task.withContainer(({ Audit }) => (action, success, error) => {
-  const details = merge({ success }, ((error != null) ? Problem.serializable(error) : null));
-  return Audit.log(null, action, null, details);
-});
+const auditLog = task.withContainer(({ Audit }) => (action, success, details) =>
+  Audit.log(null, action, null, merge({ success }, details))
+);
 const auditing = (action, t) => ((typeof t === 'function')
   ? auditing(action, t())
   : t.then(
-    ((result) => auditLog(action, true).then(
+    ((result) => auditLog(action, true, result).then(
       (() => Promise.resolve(result)),
       ((auditError) => {
         writeToStderr('Failed to audit-log task success message!');
@@ -91,7 +91,7 @@ const auditing = (action, t) => ((typeof t === 'function')
         return Promise.resolve(result);
       })
     )),
-    ((error) => auditLog(action, false, error).then(
+    ((error) => auditLog(action, false, Option.of(error).map(Problem.serializable).orNull()).then(
       (() => Promise.reject(error)),
       ((auditError) => {
         writeToStderr('Failed to audit-log task failure message!');

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -49,9 +55,9 @@
       }
     },
     "ajv-keywords": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
     "align-text": {
@@ -267,6 +273,15 @@
             "has-ansi": "2.0.0",
             "strip-ansi": "3.0.1",
             "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -555,11 +570,6 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
         },
         "needle": {
           "version": "2.2.0",
@@ -1331,6 +1341,12 @@
         "rimraf": "2.6.2"
       },
       "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -1534,9 +1550,9 @@
       }
     },
     "eslint": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.7.2.tgz",
-      "integrity": "sha1-/29fUZOEiifum2J74+c/ucteZi4=",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -1547,20 +1563,20 @@
         "debug": "3.1.0",
         "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
         "espree": "3.5.4",
         "esquery": "1.0.1",
-        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "9.18.0",
+        "globals": "11.5.0",
         "ignore": "3.3.8",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
         "is-resolvable": "1.1.0",
         "js-yaml": "3.11.0",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.10",
         "minimatch": "3.0.4",
@@ -1570,20 +1586,15 @@
         "path-is-inside": "1.0.2",
         "pluralize": "7.0.0",
         "progress": "2.0.0",
+        "regexpp": "1.1.0",
         "require-uncached": "1.0.3",
         "semver": "5.5.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
-        "table": "4.0.3",
+        "table": "4.0.2",
         "text-table": "0.2.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -1593,14 +1604,11 @@
             "ms": "2.0.0"
           }
         },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
         }
       }
     },
@@ -1678,6 +1686,12 @@
         "esrecurse": "4.2.1",
         "estraverse": "4.2.0"
       }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
     },
     "espree": {
       "version": "3.5.4",
@@ -1982,6 +1996,14 @@
       "requires": {
         "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "fill-range": {
@@ -2215,9 +2237,9 @@
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+      "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
       "dev": true
     },
     "globby": {
@@ -2234,6 +2256,12 @@
         "pinkie-promise": "2.0.1"
       },
       "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -2498,39 +2526,6 @@
         "string-width": "2.1.1",
         "strip-ansi": "4.0.0",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
       }
     },
     "interpret": {
@@ -2634,6 +2629,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-glob": {
       "version": "3.1.0",
@@ -2783,12 +2784,6 @@
         "wordwrap": "1.0.0"
       },
       "dependencies": {
-        "abbrev": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-          "dev": true
-        },
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -2819,15 +2814,6 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.0.9"
-          }
         },
         "resolve": {
           "version": "1.1.7",
@@ -2873,14 +2859,11 @@
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
-    "json-stable-stringify": {
+    "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2",
@@ -2892,12 +2875,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
       "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
     },
     "jwa": {
       "version": "1.1.5",
@@ -2957,11 +2934,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -3235,9 +3207,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -3264,6 +3236,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "mocha": {
@@ -3375,13 +3354,6 @@
         "on-finished": "2.3.0",
         "type-is": "1.6.16",
         "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-        }
       }
     },
     "mustache": {
@@ -3395,9 +3367,9 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "nanomatch": {
       "version": "1.2.9",
@@ -3477,6 +3449,15 @@
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-4.4.2.tgz",
       "integrity": "sha512-sstDxbCSPHDXrWRQhH++khr3yVU0CGvH2dCtAHOPQQ0lRR7xwq2txItEXckMpX481B/cN+0akER2bfExh7Gu/Q=="
     },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
+      }
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -3485,7 +3466,7 @@
       "requires": {
         "hosted-git-info": "2.6.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
+        "semver": "4.3.2",
         "validate-npm-package-license": "3.0.3"
       }
     },
@@ -3498,10 +3479,9 @@
       }
     },
     "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -3603,10 +3583,16 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
+        "minimist": "0.0.10",
         "wordwrap": "0.0.3"
       },
       "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -3786,11 +3772,6 @@
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
           "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
-        },
-        "semver": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
         }
       }
     },
@@ -4073,6 +4054,12 @@
         "safe-regex": "1.1.0"
       }
     },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4215,10 +4202,9 @@
       }
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
     },
     "send": {
       "version": "0.16.2",
@@ -4375,14 +4361,6 @@
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        }
       }
     },
     "snapdragon": {
@@ -4606,6 +4584,16 @@
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
       "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y="
     },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      }
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -4615,12 +4603,20 @@
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
       }
     },
     "strip-bom": {
@@ -4683,62 +4679,17 @@
       }
     },
     "table": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
-      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "6.4.0",
-        "ajv-keywords": "3.2.0",
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
         "chalk": "2.3.2",
         "lodash": "4.17.10",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1",
-            "uri-js": "3.0.2"
-          }
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
       }
     },
     "tar-stream": {
@@ -4963,23 +4914,6 @@
         }
       }
     },
-    "uri-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
-      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
-      "dev": true,
-      "requires": {
-        "punycode": "2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-          "dev": true
-        }
-      }
-    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -4991,7 +4925,7 @@
       "integrity": "sha1-Ciq/t9xCZ/czsPjy/H8siV1ApBM=",
       "requires": {
         "bindings": "1.3.0",
-        "nan": "2.6.2"
+        "nan": "2.10.0"
       }
     },
     "use": {

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   },
   "devDependencies": {
     "app-root-path": "~2",
-    "eslint": "~4.7",
-    "eslint-config-airbnb-base": "^12.0.0",
-    "eslint-plugin-import": "^2.7.0",
+    "eslint": "~4",
+    "eslint-config-airbnb-base": "~12",
+    "eslint-plugin-import": "~2",
     "istanbul": "~0.4",
     "mocha": "~3",
     "node-mocks-http": "~1.6",

--- a/test/integration/api/config.js
+++ b/test/integration/api/config.js
@@ -21,8 +21,9 @@ describe('api: /config', () => {
             asAlice.get('/v1/config/backups')
               .expect(200)
               .then(({ body }) => {
-                body.config.should.eql({ type: 'google' });
-                (body.latest == null).should.equal(true);
+                body.type.should.equal('google');
+                body.setAt.should.be.an.isoDate();
+                body.recent.should.eql([]);
               })))));
 
       it('should return latest result if logged', testService((service, { all, Audit, Config }, finalize) =>
@@ -34,9 +35,9 @@ describe('api: /config', () => {
           asAlice.get('/v1/config/backups')
             .expect(200)
             .then(({ body }) => {
-              body.config.should.eql({ type: 'google' });
-              body.latest.details.should.eql({ order: 'second' });
-              body.latest.loggedAt.should.be.a.recentIsoDate();
+              body.type.should.equal('google');
+              body.recent.map((log) => log.details).should.eql([{ order: 'second' }, { order: 'first' }]);
+              body.recent.forEach((log) => log.loggedAt.should.be.a.recentIsoDate());
             })))));
     });
 

--- a/test/integration/task/config.js
+++ b/test/integration/task/config.js
@@ -12,6 +12,7 @@ describe('task: config', () => {
         .then((result) => {
           result.key.should.equal('testConfig');
           JSON.parse(result.value).should.eql({ key: 'value' });
+          result.setAt.should.be.an.instanceof(Date);
         })));
 
     it('should reject if configuration is not found', testTask((_, finalize) =>

--- a/test/integration/task/config.js
+++ b/test/integration/task/config.js
@@ -2,17 +2,32 @@ const appRoot = require('app-root-path');
 const should = require('should');
 const { testTask } = require('../setup');
 const { getOrNotFound } = require(appRoot + '/lib/util/promise');
-const { getConfiguration, setConfiguration } = require(appRoot + '/lib/task/config');
+const { getConfiguration, getConfigurationJsonValue, setConfiguration } = require(appRoot + '/lib/task/config');
 
 describe('task: config', () => {
   describe('getConfiguration', () => {
-    it('should fetch and parse configuration by key', testTask(({ Config }, finalize) =>
+    it('should fetch configuration by key', testTask(({ Config }, finalize) =>
       finalize(Config.set('testConfig', { key: 'value' }))
         .then(() => getConfiguration('testConfig'))
-        .then((result) => result.should.eql({ key: 'value' }))));
+        .then((result) => {
+          result.key.should.equal('testConfig');
+          JSON.parse(result.value).should.eql({ key: 'value' });
+        })));
 
     it('should reject if configuration is not found', testTask((_, finalize) =>
       getConfiguration('nonexistent').should.be.rejected()));
+  });
+
+  describe('getConfigurationJsonValue', () => {
+    it('should parse the configuration value', testTask(({ Config }, finalize) =>
+      finalize(Config.set('testConfig', { key: 'value' }))
+        .then(() => getConfigurationJsonValue('testConfig'))
+        .then((result) => {
+          result.should.eql({ key: 'value' });
+        })));
+
+    it('should reject if configuration is not found', testTask((_, finalize) =>
+      getConfigurationJsonValue('nonexistent').should.be.rejected()));
   });
 
   describe('setConfiguration', () => {

--- a/test/integration/task/task.js
+++ b/test/integration/task/task.js
@@ -42,12 +42,12 @@ describe('task: runner', () => {
 describe('task: auditing', () => {
   context('on task success', () => {
     it('should log', testTask(({ simply, Audit }, finalize) =>
-      auditing('testAction', Promise.resolve(true))
+      auditing('testAction', Promise.resolve({ key: 'value' }))
         .then(() => finalize(simply.getAll('audits', Audit))
           .then((audits) => {
             audits.length.should.equal(1);
             audits[0].action.should.equal('testAction');
-            audits[0].details.should.eql({ success: true });
+            audits[0].details.should.eql({ success: true, key: 'value' });
           }))));
 
     it('should fault but passthrough on log failure', testTask(({ Audit }) => {


### PR DESCRIPTION
So, the present API had some problems.

* The release criteria say that only if no backup has succeeded in three days should the UI show a scary message. But the API only returned the latest result, so this was not possible.
* There was not a lot of information in the audit logging on which backup attempts associated with which backup configuration.

This PR ameliorates this somewhat such that `GET /config/backups` now returns:

```
{ "type": "google", "setAt": "0000-00-00T00:00:00.000Z", "recent": [{ AuditLog }, { AuditLog }] }
```

And for successful backup runs, the AuditLog `details` field now also contains a `configSetAt` key with the `setAt` of the backup config that was used. Sadly, I still don't know how to log this information for failures, since getting the configuration can itself be the failure and therefore the generic code that catches the problem can't really know about it.