### PR TITLE
bug #94: correctly enforce form version uniqueness for empty versions.

### DIFF
--- a/lib/model/instance/form.js
+++ b/lib/model/instance/form.js
@@ -69,8 +69,7 @@ module.exports = Instance.with(ActeeTrait)(({ simply, Form, forms }) => class {
       dataNode
         .map((data) => findAndTraverse(data, '@_version'))
         .map((versionNode) => versionNode.val)
-        .map((versionValue) => ((versionValue === '') ? null : versionValue))
-        .orNull();
+        .orElse('');
 
     // find and cache form name.
     const name =

--- a/lib/model/instance/submission.js
+++ b/lib/model/instance/submission.js
@@ -20,10 +20,8 @@ const out = {};
 // TODO/CR: should this be in its own file for consistency?
 out.PartialSubmission = Instance(({ Submission }) => class {
   complete(form, maybeActor) {
-    // we have to test direct equality but also relax the case that both values are
-    // nullish, since the database will tell us null but directly-initialized instances will
-    // tell us undefined.
-    if ((this.version !== form.version) && !((this.version == null) && (form.version == null)))
+    // TODO it's awkward that this error/message is thrown here; should be closer to edge.
+    if (this.version !== form.version)
       throw Problem.user.unexpectedValue({ field: 'version', value: this.version, reason: 'The submission could not be accepted because your copy of this form is an outdated version. Please get the latest version and try again.' });
 
     const actorId = Option.of(maybeActor).map((actor) => actor.id).orNull();
@@ -81,8 +79,7 @@ out.Submission = Instance(({ PartialSubmission, Attachment, Blob, simply, submis
     const version = dataNode
       .map((node) => findAndTraverse(node, '@_version'))
       .map((versionNode) => versionNode.val)
-      .map((x) => ((x === '') ? null : x))
-      .orNull();
+      .orElse('');
 
     return resolve(new PartialSubmission({ xmlFormId: xmlFormId.get(), instanceId, version, xml }));
   }

--- a/lib/model/migrations/20180515-01-enforce-nonnull-form-version.js
+++ b/lib/model/migrations/20180515-01-enforce-nonnull-form-version.js
@@ -1,0 +1,10 @@
+
+const up = (knex) =>
+  knex.raw('update forms set version=\'\' where version is null;')
+    .then(() => knex.schema.table('forms', (forms) => forms.text('version').notNullable().alter()));
+
+const down = (knex) =>
+  knex.schema.table('forms', (forms) => forms.text('version').nullable().alter());
+
+module.exports = { up, down };
+

--- a/test/unit/model/instance/form.js
+++ b/test/unit/model/instance/form.js
@@ -54,10 +54,10 @@ describe('Form', () => {
       }).point();
     });
 
-    it('should reduce empty-string version to null', (done) => {
-      const xml = '<html><head><model><instance><data id="mycoolform" version=""><field/></data></instance></model></head></html>';
+    it('should squash null version to empty-string', (done) => {
+      const xml = '<html><head><model><instance><data id="mycoolform"><field/></data></instance></model></head></html>';
       Form.fromXml(xml).then((form) => {
-        (form.version === null).should.equal(true);
+        (form.version === '').should.equal(true);
         done();
       }).point();
     });

--- a/test/unit/model/instance/submission.js
+++ b/test/unit/model/instance/submission.js
@@ -63,10 +63,10 @@ describe('Submission', () => {
       }).point();
     });
 
-    it('should squash version to null if empty string is given', (done) => {
-      const xml = '<data id="mycoolform" version=""><orx:meta><orx:instanceID>myinstance</orx:instanceID></orx:meta><field/></data>';
+    it('should squash null version to empty-string', (done) => {
+      const xml = '<data id="mycoolform"><orx:meta><orx:instanceID>myinstance</orx:instanceID></orx:meta><field/></data>';
       Submission.fromXml(xml).then((ps) => {
-        (ps.version === null).should.equal(true);
+        (ps.version === '').should.equal(true);
         done();
       }).point();
     });
@@ -88,7 +88,7 @@ describe('Submission', () => {
     const psp = Submission.fromXml(subXml).point();
     it('should complete given a form and no actor', (done) => {
       psp.then((ps) => {
-        const submission = ps.complete({ id: 42 }, Option.none());
+        const submission = ps.complete({ id: 42, version: '' }, Option.none());
         submission.instanceId.should.be.a.uuid();
         submission.xml.should.equal(subXml);
         submission.formId.should.equal(42);
@@ -100,7 +100,7 @@ describe('Submission', () => {
 
     it('should complete given a form and an actor', (done) => {
       psp.then((ps) => {
-        const submission = ps.complete({ id: 42 }, Option.of({ id: 75 }));
+        const submission = ps.complete({ id: 42, version: '' }, Option.of({ id: 75 }));
         submission.instanceId.should.be.a.uuid();
         submission.xml.should.equal(subXml);
         submission.formId.should.equal(42);


### PR DESCRIPTION
* for some reason i was squashing empty strings to nulls for Form
  version. but postgres, like most RDBMSs, does not enforce uniqueness
  on null values.
* so multiple forms can be uploaded without version values (provided the
  old ones are deleted), which is not our intention; these duplicates
  should be prevented.
* so instead we squash nulls to empty-string throughout.
* and to cap it off we add a non-null constraint on the Form version
  column to be completely sure we haven't missed any cases.
* resolves #94.