### PR TITLE
bug #92: should return success object rather than string on PATCH forms.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -467,9 +467,7 @@ We use `PATCH` rather than `PUT` to represent the update operation, so that you 
         + state (Form State, optional) - If supplied, the Form lifecycle state will move to this value.
 
 + Response 200 (application/json)
-    + Attributes (Form)
-        + name: `A New Name` (string, required) - The updated friendly name can be seen here.
-        + state: `closing` (Form State, required) - The updated `Form` state can be seen here.
+    + Attributes (Success)
 
 + Response 400 (application/json)
     + Attributes (Error 400)

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -45,7 +45,8 @@ module.exports = (service, { env, Actee, Form, Audit }) => {
     Form.getByXmlFormId(params.id)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('update', form)
-        .then(() => form.with(Form.fromApi(body)).update()))));
+        .then(() => form.with(Form.fromApi(body)).update())
+        .then(success))));
 
   service.delete('/forms/:id', endpoint(({ auth, params }) =>
     Form.getByXmlFormId(params.id)


### PR DESCRIPTION
* see ticket for details.
* should probably eventually return the updated object but we'll worry
  about that later.
* resolves #92.