### PR TITLE
new+test: re-enable GET /users/:id.

### DIFF
--- a/lib/resources/users.js
+++ b/lib/resources/users.js
@@ -69,16 +69,17 @@ module.exports = (service, { Actee, User, mail }) => {
       .orElse(Problem.user.notFound())));
 
 
-  /* The following endpoints are not part of v1 scope. so rather than expose hidden
-   * surfaces that will not be well-tested, we shall simply comment them out for now.
-
   // Gets full details of a user by actor id.
-  // TODO: probably hide email addresses unless admin/self?
+  // TODO: infosec debate around 404 vs 403 if insufficient privs but record DNE.
+  // TODO: once we have non-admins, probably hide email addresses unless admin/self?
   service.get('/users/:id', endpoint(({ auth, params }) =>
     User.getByActorId(params.id)
       .then(getOrNotFound)
-      .then((user) => auth.canOrReject('read', user)
+      .then((user) => auth.canOrReject('read', user.actor)
         .then(() => user))));
+
+  /* The following endpoints are not part of v1 scope. so rather than expose hidden
+   * surfaces that will not be well-tested, we shall simply comment them out for now.
 
   // TODO: infosec debate around 404 vs 403 if insufficient privs but record DNE.
   service.put('/users/:id', endpoint(({ params, body, auth }) =>

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -171,5 +171,29 @@ describe('api: /users', () => {
           .expect(200)
           .then(({ body }) => body.email.should.equal('chelsea@opendatakit.org')))));
   });
+
+  describe('/users/:id GET', () => {
+    it('should reject if the authed user cannot get', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.get('/v1/users/current')
+          .expect(200)
+          .then(({ body }) => service.login('chelsea', (asChelsea) =>
+            asChelsea.get(`/v1/users/${body.id}`).expect(403))))));
+
+    it('should return the requested user', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.get('/v1/users/current')
+          .expect(200)
+          .then(({ body }) => asAlice.get(`/v1/users/${body.id}`)
+            .expect(200)
+            .then(({ body }) => {
+              body.should.be.a.User();
+              body.email.should.equal('alice@opendatakit.org');
+            })))));
+
+    it('should reject if the user does not exist', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.get('/v1/users/99').expect(404))));
+  });
 });
 


### PR DESCRIPTION
* since we are already exposing email addresses via /users listing, and
  only people who can GET /users can GET /users/:id on anyone but
  themselves anyway.